### PR TITLE
Added advisory archive URL flag to specify custom DB

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ var (
 func main() {
 	format := flag.String("format", "ansi", "Output format (ansi, markdown, json, or yaml)")
 	path := flag.String("path", "", "composer.lock file or directory")
+	advisoryArchiveURL := flag.String("archive", security.AdvisoryArchiveURL, "Advisory archive URL")
 	local := flag.Bool("local", false, "Do not make HTTP calls (needs a valid cache file)")
 	updateCacheOnly := flag.Bool("update-cache", false, "Update the cache (other flags are ignored)")
 	help := flag.Bool("help", false, "Output help and version")
@@ -41,7 +42,7 @@ func main() {
 	}
 
 	if *updateCacheOnly {
-		if err := db.Load(); err != nil {
+		if err := db.Load(*advisoryArchiveURL); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(127)
 		}

--- a/security/advisories.go
+++ b/security/advisories.go
@@ -59,7 +59,7 @@ func NewDB(noHTTPCalls bool) (*AdvisoryDB, error) {
 // Load Loads fetches the database from Github and reads/loads current advisories
 // from the repository. Cache handling is delegated to http.Transport and
 // **must** be handled appropriately.
-func (db *AdvisoryDB) Load() error {
+func (db *AdvisoryDB) Load(advisoryArchiveURL string) error {
 	if len(db.Advisories) > 0 {
 		return nil
 	}
@@ -78,7 +78,7 @@ func (db *AdvisoryDB) Load() error {
 	}
 
 	if !db.noHTTPCalls {
-		req, err := http.NewRequest("GET", AdvisoryArchiveURL, nil)
+		req, err := http.NewRequest("GET", advisoryArchiveURL, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
For example clone FriendsOfPHP/security-advisories to another server