### PR TITLE
Be more lenient with non-standard pre-release versions (alpha12 -> alpha.12)

### DIFF
--- a/security/fixtures/prerelease_without_dot.lock
+++ b/security/fixtures/prerelease_without_dot.lock
@@ -1,0 +1,12 @@
+{
+    "packages": [
+        {
+            "name": "symfony/apache-pack",
+            "version": "v1.0.0-alpha10"
+        },
+        {
+            "name": "test/packagename",
+            "version": "2.0-beta3"
+        }
+    ]
+}

--- a/security/lock_test.go
+++ b/security/lock_test.go
@@ -48,3 +48,13 @@ func TestLocateLock(t *testing.T) {
 		assert.Nil(t, err)
 	}
 }
+
+func TestPrereleaseWithoutDot(t *testing.T) {
+	file, err := os.Open("fixtures/prerelease_without_dot.lock")
+	if err != nil {
+		panic(err)
+	}
+	lock, err := NewLock(bufio.NewReader(file))
+	assert.Equal(t, lock.Packages[0].Version, Version("v1.0.0-alpha.10"))
+	assert.Equal(t, lock.Packages[1].Version, Version("2.0-beta.3"))
+}

--- a/security/version.go
+++ b/security/version.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"encoding/json"
+	"regexp"
 )
 
 // Version represents a composer.json version (can be a string or an integer)
@@ -20,6 +21,11 @@ func (v *Version) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &tmp); err != nil {
 		return err
 	}
+
+	// be more lenient with pre-release versions, convert "2.0.0-alpha12" to "2.0.0-alpha.12"
+	re := regexp.MustCompile(`(alpha|beta)(\d+)$`)
+	tmp = re.ReplaceAllString(tmp, "$1.$2")
+
 	*v = Version(tmp)
 	return nil
 }


### PR DESCRIPTION
This fixes #9.