### PR TITLE
Insert the dot for pre-release-versions also for RC and case-insensitive

### DIFF
--- a/security/fixtures/prerelease_without_dot.lock
+++ b/security/fixtures/prerelease_without_dot.lock
@@ -7,6 +7,10 @@
         {
             "name": "test/packagename",
             "version": "2.0-beta3"
+        },
+        {
+            "name": "test/another",
+            "version": "2.0-RC1"
         }
     ]
 }

--- a/security/lock_test.go
+++ b/security/lock_test.go
@@ -57,4 +57,5 @@ func TestPrereleaseWithoutDot(t *testing.T) {
 	lock, err := NewLock(bufio.NewReader(file))
 	assert.Equal(t, lock.Packages[0].Version, Version("v1.0.0-alpha.10"))
 	assert.Equal(t, lock.Packages[1].Version, Version("2.0-beta.3"))
+	assert.Equal(t, lock.Packages[2].Version, Version("2.0-RC.1"))
 }

--- a/security/version.go
+++ b/security/version.go
@@ -23,7 +23,7 @@ func (v *Version) UnmarshalJSON(b []byte) error {
 	}
 
 	// be more lenient with pre-release versions, convert "2.0.0-alpha12" to "2.0.0-alpha.12"
-	re := regexp.MustCompile(`(alpha|beta)(\d+)$`)
+	re := regexp.MustCompile(`(?i)(alpha|beta|rc)(\d+)$`)
 	tmp = re.ReplaceAllString(tmp, "$1.$2")
 
 	*v = Version(tmp)


### PR DESCRIPTION
Based on the discussion in #26.