### PR TITLE
Implemented no-dev flag (fixes #30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ flag (supported formats: `ansi`, `markdown`, `json`, `junit`, and `yaml`):
 
     $ local-php-security-checker --format=json
 
+All packages are checked for security vulnerabilities by default. You can skip the checks for packages listed in `require-dev` by passing the `no-dev` flag:
+
+    $ local-php-security-checker --no-dev
+
 When running the command, it checks for an updated vulnerability database and
 downloads it from Github if it changed since the last run. If you want to avoid
 the HTTP round-trip, use `--local`. To force a database update without checking

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 	path := flag.String("path", "", "composer.lock file or directory")
 	advisoryArchiveURL := flag.String("archive", security.AdvisoryArchiveURL, "Advisory archive URL")
 	local := flag.Bool("local", false, "Do not make HTTP calls (needs a valid cache file)")
+	noDevPackages := flag.Bool("no-dev", false, "Do not check packages listed under require-dev")
 	updateCacheOnly := flag.Bool("update-cache", false, "Update the cache (other flags are ignored)")
 	help := flag.Bool("help", false, "Output help and version")
 	flag.Parse()
@@ -67,7 +68,7 @@ func main() {
 		os.Exit(127)
 	}
 
-	vulns := security.Analyze(lock, db)
+	vulns := security.Analyze(lock, db, *noDevPackages)
 
 	output, err := security.Format(vulns, *format)
 	if err != nil {

--- a/security/analyzer.go
+++ b/security/analyzer.go
@@ -74,9 +74,13 @@ func (v *Vulnerabilities) Get(pkg string) *Vulnerability {
 }
 
 // Analyze checks if a give lock references packages with known security issues
-func Analyze(lock *Lock, db *AdvisoryDB) *Vulnerabilities {
+func Analyze(lock *Lock, db *AdvisoryDB, noDevPackages bool) *Vulnerabilities {
 	vulnerabilities := make(Vulnerabilities)
-	for _, p := range append(lock.Packages, lock.DevPackages...) {
+	packages := lock.Packages
+	if !noDevPackages {
+		packages = append(packages, lock.DevPackages...)
+	}
+	for _, p := range packages {
 		var advs []SimpleAdvisory
 		composerReference := "composer://" + p.Name
 		for _, a := range db.Advisories {


### PR DESCRIPTION
This PR implements the flag `no-dev` to skip checking packages listed in `require-dev` as suggested in #30. 