### PR TITLE
Add `cache-dir` flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ func main() {
 	format := flag.String("format", "ansi", "Output format (ansi, junit, markdown, json, or yaml)")
 	path := flag.String("path", "", "composer.lock file or directory")
 	advisoryArchiveURL := flag.String("archive", security.AdvisoryArchiveURL, "Advisory archive URL")
+	cacheDir := flag.String("cache-dir", os.TempDir(), "Cache directory")
 	local := flag.Bool("local", false, "Do not make HTTP calls (needs a valid cache file)")
 	noDevPackages := flag.Bool("no-dev", false, "Do not check packages listed under require-dev")
 	updateCacheOnly := flag.Bool("update-cache", false, "Update the cache (other flags are ignored)")
@@ -37,7 +38,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	db, err := security.NewDB(*local, *advisoryArchiveURL)
+	db, err := security.NewDB(*local, *advisoryArchiveURL, *cacheDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to load the advisory DB: %s\n", err)
 		os.Exit(127)

--- a/security/advisories.go
+++ b/security/advisories.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -21,6 +20,7 @@ const AdvisoryArchiveURL = "https://codeload.github.com/FriendsOfPHP/security-ad
 // AdvisoryDB stores all known security advisories
 type AdvisoryDB struct {
 	Advisories  []Advisory
+	cacheDir    string
 	noHTTPCalls bool
 }
 
@@ -47,8 +47,8 @@ type Cache struct {
 }
 
 // NewDB fetches the advisory DB from Github
-func NewDB(noHTTPCalls bool, advisoryArchiveURL string) (*AdvisoryDB, error) {
-	db := &AdvisoryDB{noHTTPCalls: noHTTPCalls}
+func NewDB(noHTTPCalls bool, advisoryArchiveURL, cacheDir string) (*AdvisoryDB, error) {
+	db := &AdvisoryDB{noHTTPCalls: noHTTPCalls, cacheDir: cacheDir}
 	if err := db.Load(advisoryArchiveURL); err != nil {
 		return nil, fmt.Errorf("unable to fetch advisories: %s", err)
 	}
@@ -67,7 +67,7 @@ func (db *AdvisoryDB) Load(advisoryArchiveURL string) error {
 	db.Advisories = []Advisory{}
 
 	var cache *Cache
-	cachePath := filepath.Join(os.TempDir(), "php_sec_db.json")
+	cachePath := filepath.Join(db.cacheDir, "php_sec_db.json")
 	if cacheContent, err := ioutil.ReadFile(cachePath); err == nil {
 		// ignore errors
 		json.Unmarshal(cacheContent, &cache)


### PR DESCRIPTION
Specify where to store cache files.
Useful for CI/CD when `/tmp` folder is not suitable for reuse.