### PR TITLE
[JUnit] Fix multiple vulns

### DIFF
--- a/security/junit.go
+++ b/security/junit.go
@@ -24,7 +24,7 @@ type testcase struct {
 	XMLName   xml.Name `xml:"testcase"`
 	Name      string   `xml:"name,attr"`
 	Classname string   `xml:"classname,attr"`
-	Failure   string   `xml:"failure,omitempty"`
+	Failure   []string `xml:"failure,omitempty"`
 }
 
 func ToJunit(vulns *Vulnerabilities) ([]byte, error) {
@@ -38,7 +38,7 @@ func ToJunit(vulns *Vulnerabilities) ([]byte, error) {
 			Name:      fmt.Sprintf("%s (%s)", pkg, v.Version),
 		}
 		for _, a := range v.Advisories {
-			tc.Failure = fmt.Sprintf("%s - %s (%s)", a.CVE, a.Title, a.Link)
+			tc.Failure = append(tc.Failure, fmt.Sprintf("%s - %s (%s)", a.CVE, a.Title, a.Link))
 		}
 		cases = append(cases, tc)
 		ts.Failures++


### PR DESCRIPTION
When a package as multiples vulnerabilities, the junit format only report one which is not the intended use case.

As reported here: https://github.com/fabpot/local-php-security-checker/pull/23#issuecomment-1167245415

Sample with the following composer.json
```json
{
  "require": {
    "guzzlehttp/guzzle": "7.4.2"
  }
}
```

Currently the result is the following:
```xml
./local-php-security-checker --path=test/ --format=junit
  <testsuites name="Symfony Security Check Report">
      <testsuite package="" errors="0" failures="1" tests="1">
          <testcase name="guzzlehttp/guzzle (7.4.2)" classname="packages">
              <failure>CVE-2022-31091 - Change in port should be considered a change in origin (https://github.com/guzzle/guzzle/security/advisories/GHSA-q559-8m2m-g699)</failure>
          </testcase>
      </testsuite>
  </testsuites>
```

With the modification I did:
```xml
./local-php-security-checker --path=test/ --format=junit
  <testsuites name="Symfony Security Check Report">
      <testsuite package="" errors="0" failures="1" tests="1">
          <testcase name="guzzlehttp/guzzle (7.4.2)" classname="packages">
              <failure>CVE-2022-29248 - Cross-domain cookie leakage (https://github.com/guzzle/guzzle/security/advisories/GHSA-cwmx-hcrq-mhc3)</failure>
              <failure>CVE-2022-31042 - Failure to strip the Cookie header on change in host or HTTP downgrade (https://github.com/guzzle/guzzle/security/advisories/GHSA-f2wf-25xc-69c9)</failure>
              <failure>CVE-2022-31043 - Fix failure to strip Authorization header on HTTP downgrade (https://github.com/guzzle/guzzle/security/advisories/GHSA-w248-ffj2-4v5q)</failure>
              <failure>CVE-2022-31090 - CURLOPT_HTTPAUTH option not cleared on change of origin (https://github.com/guzzle/guzzle/security/advisories/GHSA-25mq-v84q-4j7r)</failure>
              <failure>CVE-2022-31091 - Change in port should be considered a change in origin (https://github.com/guzzle/guzzle/security/advisories/GHSA-q559-8m2m-g699)</failure>
          </testcase>
      </testsuite>
  </testsuites>
```