### PR TITLE
Take input format for github action output

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 
 	if os.Getenv("GITHUB_WORKSPACE") != "" {
 		// inside a Github action, export vulns
-		if output, err := security.Format(vulns, "raw_json"); err != nil {
+		if output, err := security.Format(vulns, "raw_json"); err == nil {
 			fmt.Printf("::set-output name=vulns::%s", output)
 		}
 	}

--- a/security/formatter.go
+++ b/security/formatter.go
@@ -16,7 +16,9 @@ func Format(vulns *Vulnerabilities, format string) ([]byte, error) {
 	} else if format == "text" || format == "txt" || format == "markdown" || format == "md" {
 		return ToMarkdown(vulns), nil
 	} else if format == "json" {
-		return ToJSON(vulns)
+		return ToJSON(vulns, true)
+	} else if format == "raw_json" {
+		return ToJSON(vulns, false)
 	} else if format == "junit" {
 		return ToJunit(vulns)
 	} else if format == "yaml" || format == "yml" {
@@ -78,8 +80,12 @@ func ToMarkdown(vulns *Vulnerabilities) []byte {
 }
 
 // ToJSON outputs vulnerabilities as JSON
-func ToJSON(vulns *Vulnerabilities) ([]byte, error) {
-	return json.MarshalIndent(vulns, "", "    ")
+func ToJSON(vulns *Vulnerabilities, prettify bool) ([]byte, error) {
+	if prettify {
+		return json.MarshalIndent(vulns, "", "    ")
+	}
+
+	return json.Marshal(vulns)
 }
 
 // ToYAML outputs vulnerabilities as YAML


### PR DESCRIPTION
The "raw_json" doesn't exist in the formatter file so the github action output was all the time empty.

I have choosen to put the same output as requested by the user.
An other solution can be to add the raw_json format.

What do you think about this choice ?