### PR TITLE
chore(deps): bump go from 1.19 to 1.22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,20 +8,24 @@ jobs:
     releaser:
         name: Release
         runs-on: ubuntu-latest
+        env:
+            flags: ""
         steps:
+            -   if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+                run: echo "flags=--snapshot" >> "$GITHUB_ENV"
             -
                 name: Checkout
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
             -
                 name: Set up Go
-                uses: actions/setup-go@v3
+                uses: actions/setup-go@v5
                 with:
                     go-version-file: 'go.mod'
             -
                 name: Run GoReleaser
-                uses: goreleaser/goreleaser-action@v3
+                uses: goreleaser/goreleaser-action@v5
                 with:
                     version: latest
-                    args: release --rm-dist
+                    args: release --clean ${{ env.flags }}
                 env:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
     releaser:
         name: Release
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
         steps:
             -
                 name: Checkout
@@ -16,7 +16,7 @@ jobs:
                 name: Set up Go
                 uses: actions/setup-go@v3
                 with:
-                    go-version: 1.22
+                    go-version-file: 'go.mod'
             -
                 name: Run GoReleaser
                 uses: goreleaser/goreleaser-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
     releaser:
         name: Release
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             -
                 name: Checkout
@@ -16,7 +16,7 @@ jobs:
                 name: Set up Go
                 uses: actions/setup-go@v3
                 with:
-                    go-version: 1.19
+                    go-version: 1.22
             -
                 name: Run GoReleaser
                 uses: goreleaser/goreleaser-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
     test:
         name: Test
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
         steps:
             -
                 name: Checkout
@@ -16,7 +16,7 @@ jobs:
                 name: Set up Go
                 uses: actions/setup-go@v3
                 with:
-                    go-version: 1.22
+                    go-version-file: 'go.mod'
             -
                 name: Run tests
                 run: go test ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
         steps:
             -
                 name: Checkout
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
             -
                 name: Set up Go
-                uses: actions/setup-go@v3
+                uses: actions/setup-go@v5
                 with:
                     go-version-file: 'go.mod'
             -

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
     test:
         name: Test
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             -
                 name: Checkout
@@ -16,7 +16,7 @@ jobs:
                 name: Set up Go
                 uses: actions/setup-go@v3
                 with:
-                    go-version: 1.19
+                    go-version: 1.22
             -
                 name: Run tests
                 run: go test ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.0 (TBD)
+
+ * Move to Go 1.22
+
 # 2.0.0 (2022-04-09)
 
  * Add --cache-dir
@@ -7,6 +11,7 @@
 # 1.2.0 (2021-09-21)
 
  * Add --no-dev
+
 # 1.1.0 (2021-08-31)
 
  * Add an example about how to use the tool in a cron

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/fabpot/local-php-security-checker/v2
 
-go 1.19
+go 1.22
 
 require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.9.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
@@ -7,15 +6,9 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
I upgraded the following:
* Go from 1.19 to 1.22
* github.com/stretchr/testify from 1.8.1 to 1.9.0
* Ubuntu from 20.04 to 22.04 in the github workflow

And I cleaned the go.sum with a `go mod tidy`.


If you want that in multiple PR I can split.
~~I also wondered if I should upgrade the Github Actions too but I'm not confident about it and it would be too much for this PR.~~ I did upgrade the Github Actions in the end.